### PR TITLE
Implemented a very simple server to pipe the DJI USB to WiFi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ To this:
 
 If there is any issue, please check on our [Discord server](https://discord.gg/uGYMNByeTH), some people might help you there. You can also consult the [DigiView Wiki.](https://github.com/fpvout/fpvout.com/wiki)
 
+## Experimental
+- The WiFi module can be used to pipe the USB from the goggles to a WiFi client. This can allow devices that are unsupported by libUSB (iOS) to act as a screen. There is currently no service setup up for this. See fpvout-stream-listen.py for more details.
+
 ## Known Issues
 - Do not plug into the Pi until after video is showing in your goggles.
 - If you need to power cycle the air unit, you may need to replug the USB cable in order to re-establish the stream.

--- a/Scripts/fpvout-start.sh
+++ b/Scripts/fpvout-start.sh
@@ -4,4 +4,22 @@ export DISPLAY=:0;
 
 cd /home/fpvout/Scripts/fpv-c/ 
 
-./fpv-video-out | /opt/vc/src/hello_pi/hello_video/hello_video.bin
+# If there is no display connected don't start streaming with fpv-video-out.
+# At best it's a waste of resources, at worst it will prevent the WiFi 
+# stream from obtaining the USB connection.
+#
+# NOTE This is pretty poorly tested (and understood by me). I don't even
+#      have an HDMI cable for this PI right now, so I can't test the case
+#      where the display is available. I also suspect that this wouldn't 
+#      work with composite video out, which is a pretty valid use case
+#      for using an old analog monitor (like the one sitting in my garage).
+#      I could probably embed a PI zero inside of that display and get a
+#      high quality but low res stream for passengers.
+displayStatus=$(/usr/bin/tvservice -s)
+displayDetect="[TV is off]"
+if [[ "$displayStatus" ==  *"$displayStatus"* ]]; then
+    echo "No HDMI display connected, not streaming to screen. $displayStatus"
+else
+    echo "HDMI display detected, streaming to screen. $displayStatus"
+    ./fpv-video-out | /opt/vc/src/hello_pi/hello_video/hello_video.bin
+fi

--- a/Scripts/fpvout-stream-listen.py
+++ b/Scripts/fpvout-stream-listen.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+# 
+# A server that waits for connections and pipes the output of fpv-c to the 
+# remote client. The client will be an h264 stream (without an MP4 wrapper)
+# so clients will need to act accordingly. To view the stream in VLC open
+# a url: tcp/h264://fpvout.local:8081
+# 
+# This service can be used to create a simple device that will clients such
+# as iOS to connect to DJI FPV goggles. I haven't tested yet, but I suspect
+# even a Pi Zero could handle it since it's just redirecting USB to Wifi and
+# not even decoding the video. That said my Pi 4 has horrible latency, so this
+# may not work.
+
+import socket
+import subprocess
+import sys
+
+# Create a TCP/IP socket
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+# Bind the socket to the port
+server_address = ('', 8081)
+print('starting up on %s port %s' % server_address, file=sys.stderr)
+sock.bind(server_address)
+
+# Listen for incoming connections
+sock.listen(1)
+
+while True:
+    # Wait for a connection
+    print('waiting for a connection', file=sys.stderr)
+    connection, client_address = sock.accept()
+
+    try:
+        print('connection from %s port %s' % client_address, file=sys.stderr)
+        
+        socket_input = connection.makefile('wb',0)
+        proc = subprocess.run(['/home/fpvout/Scripts/fpv-c/fpv-video-out'], stdout=socket_input)
+    finally:
+        # Clean up the connection
+        print('closed connection from %s port %s' % client_address, file=sys.stderr)
+        connection.close()
+


### PR DESCRIPTION
This is more of a proof of concept at this point, the latency is pretty high, but it can be used to get DJI video onto an iOS device live. I haven't created a service for it.
Since the HDMI output would likely conflict with the WiFi access (as they both need access to the USB port) I added a check to fpvout-start.sh that only enables output when an HDMI monitor is connected. This allows both modes of operation to co-exist, since the server is only triggered by an incoming connection, whereas the HDMI is triggered when the USB connection is detected. I suspect that this may not work properly if the user is using the composite out to render the video.

Some of the paths were different in the Git repository than they are on the image that I got. I've tried to use the newer path format in the repo instead of the format on the Pi image, but this isn't fully tested.